### PR TITLE
sepolicy: Fixing typos

### DIFF
--- a/prebuilts/api/33.0/public/domain.te
+++ b/prebuilts/api/33.0/public/domain.te
@@ -386,6 +386,7 @@ neverallow {
   -init
   -ueventd
   -vold
+  -recovery
 } self:global_capability_class_set mknod;
 
 # No process can map low memory (< CONFIG_LSM_MMAP_MIN_ADDR).
@@ -510,8 +511,8 @@ neverallow { domain -kernel with_asan(`-asan_extract') } { system_file_type vend
 # Don't allow mounting on top of /system files or directories
 neverallow * exec_type:dir_file_class_set mounton;
 
-# Nothing should be writing to files in the rootfs.
-neverallow * rootfs:file { create write setattr relabelto append unlink link rename };
+# Nothing should be writing to files in the rootfs, except recovery.
+neverallow { domain -recovery } rootfs:file { create write setattr relabelto append unlink link rename };
 
 # Restrict context mounts to specific types marked with
 # the contextmount_type attribute.


### PR DESCRIPTION
* Those commits are wrongly picked:
+ https://github.com/protonplus-org/system_sepolicy/commit/6447842aea8d6edc15659abcd4466dc35bcd56a5
+ https://github.com/protonplus-org/system_sepolicy/commit/6447842aea8d6edc15659abcd4466dc35bcd56a5

* It should be picked into prebuilts/api/33.0/public/domain.te instead of 31.0. Fix it.